### PR TITLE
Fix focus class triggered on click

### DIFF
--- a/src/lib/components/Skeleton.svelte
+++ b/src/lib/components/Skeleton.svelte
@@ -210,8 +210,9 @@
     color: var(--snt-color-hover) !important;
   }
 
-  .snt-skeleton:focus-within,
-  .snt-skeleton:focus {
+  /* Show focus styles only for keyboard (and similar) navigation */
+  .snt-skeleton:focus-visible,
+  .snt-skeleton:focus-within:has(:focus-visible) {
     background-color: var(--snt-bg-focus) !important;
     border-width: var(--snt-bw-focus) !important;
     border-color: var(--snt-bc-focus) !important;


### PR DESCRIPTION
Fixes issue #2: prevent focus styling from triggering on mouse click by using :focus-visible (keyboard focus) for Skeleton focus styles.\n\nChange: code:src/lib/components/Skeleton.svelte:213:3