### PR TITLE
Fix Rollup build parsing emitted CSS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,8 +10,10 @@ export default {
   ],
   plugins: [
     svelte({
+      emitCss: false,
       compilerOptions: {
-        dev: false
+        dev: false,
+        css: "injected"
       }
     }),
     resolve({ browser: true, dedupe: ['svelte'] }),

--- a/src/lib/components/SlideOver.svelte
+++ b/src/lib/components/SlideOver.svelte
@@ -1,6 +1,10 @@
 <script>
   import { fade } from "svelte/transition";
-  import { Card, VBox, HBox, Button, TextRich } from "fabkit";
+  import Card from "./Card.svelte";
+  import VBox from "./VBox.svelte";
+  import HBox from "./HBox.svelte";
+  import Button from "./Button.svelte";
+  import TextRich from "./TextRich.svelte";
 
   let {
     children,


### PR DESCRIPTION
Fixes #4.

Rollup build was failing because emitted component CSS files (e.g. `src/lib/components/*.css`) were being treated as JS modules.

Changes:
- Configure Svelte Rollup plugin to avoid emitting standalone CSS and inject CSS instead.
- Remove self-import from the library entry (`import ... from "fabkit"`) inside `SlideOver.svelte` by switching to relative imports.

Result:
- `npm run build` completes successfully.
