### PR TITLE
Support flat prop on Button

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -7,6 +7,7 @@
     children,
     disabled = false,
     type = "button",
+    flat = false,
     square = false,
     onclick,
     class: className = "",
@@ -36,7 +37,9 @@
     zIndex = 0,
     ref = $bindable(),
     ...rest
-  } = $props();
+  
+if (flat) type = \"flat\";
+} = $props();
 
   // Local derived values for fallbacks
   const finalPadding = $derived(


### PR DESCRIPTION
Expose a flat boolean prop that maps to type="flat" for backward compatibility and docs.