### PR TITLE
docs(fields): add TextArea

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@
 ### Form Fields
 
 - [TextField](./components/text-field.md) — text input
+- [TextArea](./components/text-area.md) — multiline text input
 - [SelectField](./components/select-field.md) — dropdown select
 - [BaseField](./components/base-field.md) — field primitive (for custom fields)
 

--- a/docs/components/select-field.md
+++ b/docs/components/select-field.md
@@ -39,6 +39,7 @@ import { SelectField } from 'fabkit';
 | `options` | `SelectOption[]` | `[]` | Available options |
 | `icon` | `SvelteComponent` | `""` | Phosphor icon component shown inside the field |
 | `iconPosition` | `"left" \| "right"` | `"right"` | Icon placement |
+| `flat` | `boolean` | `false` | Removes the underline |
 | `zIndex` | `number \| string` | `"auto"` | Sets the stacking context for the field; dropdown renders above it (`zIndex + 1`) |
 | `ref` | `bindable` | — | DOM element reference |
 

--- a/docs/components/text-area.md
+++ b/docs/components/text-area.md
@@ -1,0 +1,60 @@
+# TextArea
+
+A multi-line text input with a floating label.
+
+---
+
+## Import
+
+```js
+import { TextArea } from 'fabkit';
+```
+
+---
+
+## Basic Usage
+
+```svelte
+<script>
+  let description = $state('');
+</script>
+
+<TextArea
+  label="Description"
+  placeholder="Write something…"
+  bind:value={description}
+/>
+```
+
+---
+
+## Component Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | `""` | Text value — **bindable** |
+| `label` | `string` | `""` | Floating label text |
+| `placeholder` | `string` | `""` | Placeholder shown when empty |
+| `rows` | `number` | `4` | Initial row count |
+| `autoResize` | `boolean` | `false` | Auto-resize height to content |
+| `readOnly` | `boolean` | `false` | Makes the field read-only |
+| `flat` | `boolean` | `false` | Removes the underline |
+| `ref` | `bindable` | — | DOM element reference |
+
+---
+
+## Skeleton Pass-through Props
+
+TextArea is built on [Skeleton](./skeleton.md). All Skeleton props are accepted.
+
+---
+
+## Examples
+
+```svelte
+<!-- Auto-resize -->
+<TextArea label="Notes" bind:value={notes} autoResize />
+
+<!-- Flat -->
+<TextArea label="Title" bind:value={title} flat />
+```


### PR DESCRIPTION
Docs update: add TextArea documentation and list it in docs index; document SelectField \ prop.