### PR TITLE
ci: fix pnpm setup + release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 jobs:
   check:
@@ -16,12 +19,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fixes pnpm not found by installing pnpm before actions/setup-node pnpm cache. Adds triggers for tag push (v*) and release published.