### PR TITLE
ci: fix pnpm version source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
           node-version: 20
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.6
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fix CI failing with pnpm/action-setup when both workflow and package.json specify pnpm version; rely on package.json packageManager.