### PR TITLE
ci: publish on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,31 @@ jobs:
         continue-on-error: true
 
       - run: pnpm run build
+
+  publish:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
+          registry-url: https://npm.pkg.github.com
 
       - uses: pnpm/action-setup@v4
 
@@ -60,5 +63,5 @@ jobs:
 
       - run: pnpm publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-  "name": "fabkit",
+  "name": "@fabricatorsltd/fabkit",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "version": "0.0.7",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Publish to npm registry when a GitHub Release is published. Requires repository secret NPM_TOKEN.