### PR TITLE
chore: bump version to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "version": "0.0.7",
+  "version": "0.0.9",
   "scripts": {
     "build": "rollup -c",
     "prepublishOnly": "svelte-kit sync && svelte-package && rollup -c",


### PR DESCRIPTION
Fix package.json version mismatch after v0.0.8 release.