### PR TITLE
ci: publish to npm registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +46,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
+          registry-url: https://registry.npmjs.org
 
       - uses: pnpm/action-setup@v4
 
@@ -61,7 +58,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm publish --no-git-checks
+      - run: pnpm publish --no-git-checks --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fabricatorsltd/fabkit",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "version": "0.0.9",
   "scripts": {


### PR DESCRIPTION
Switch publish job to https://registry.npmjs.org and use secrets.NPM_TOKEN.

Also remove GitHub Packages registry publishConfig; keep publishConfig.access=public for scoped package.