### PR TITLE
Add density context/tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 
 - [Skeleton](./components/skeleton.md) — base layout primitive (all visual props)
 - [AdaptiveContent](./components/adaptive-content.md) — breakpoint-based content variants
+- [DensityProvider](./components/density-provider.md) — density context (compact/regular/roomy)
 
 ### Layout
 

--- a/docs/components/density-provider.md
+++ b/docs/components/density-provider.md
@@ -1,0 +1,72 @@
+# DensityProvider
+
+Sets a density context (compact / regular / roomy) that components can consume to standardize spacing and typography.
+
+It can be forced, or selected automatically by container width.
+
+---
+
+## Import
+
+```js
+import { DensityProvider } from 'fabkit';
+```
+
+---
+
+## Basic Usage
+
+```svelte
+<DensityProvider density="regular">
+  ...
+</DensityProvider>
+```
+
+---
+
+## Auto Density (container-driven)
+
+```svelte
+<DensityProvider density="auto" compactBelow={560} roomyAbove={960}>
+  ...
+</DensityProvider>
+```
+
+---
+
+## Tokens
+
+The provider sets CSS variables on its root:
+
+- `--fabkit-density` (`compact` / `regular` / `roomy`)
+- `--fabkit-density-space2`, `--fabkit-density-space4`, `--fabkit-density-space8`, `--fabkit-density-space12`, `--fabkit-density-space16`, `--fabkit-density-space24`
+- `--fabkit-density-fontSize`
+- `--fabkit-density-controlHeight`
+
+You can also override tokens:
+
+```svelte
+<DensityProvider
+  density="compact"
+  tokens={{ space12: 8, controlHeight: 26 }}
+>
+  ...
+</DensityProvider>
+```
+
+---
+
+## Consuming the context
+
+Inside a component:
+
+```svelte
+<script>
+  import { getDensityStore } from 'fabkit';
+  const density = getDensityStore();
+</script>
+
+<div style={`padding: ${$density.tokens.space12}px`}>
+  ...
+</div>
+```

--- a/src/lib/DensityContext.js
+++ b/src/lib/DensityContext.js
@@ -1,0 +1,10 @@
+import { getContext } from "svelte";
+import { readable } from "svelte/store";
+import { DENSITY_CONTEXT_KEY } from "./context.js";
+import { DENSITY_TOKENS } from "./density.js";
+
+export function getDensityStore() {
+  const store = getContext(DENSITY_CONTEXT_KEY);
+  if (store) return store;
+  return readable({ density: "regular", tokens: DENSITY_TOKENS.regular });
+}

--- a/src/lib/components/DensityProvider.svelte
+++ b/src/lib/components/DensityProvider.svelte
@@ -1,0 +1,82 @@
+<script>
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import Skeleton from "./Skeleton.svelte";
+  import { DENSITY_CONTEXT_KEY } from "../context.js";
+  import {
+    normalizeDensity,
+    resolveDensityTokens,
+    densityTokensToCssVars,
+  } from "../density.js";
+
+  let {
+    density = "auto",
+    compactBelow = 560,
+    roomyAbove = 960,
+    tokens,
+
+    class: className = "",
+    children,
+    ref = $bindable(),
+    ...rest
+  } = $props();
+
+  let availableWidth = $state(undefined);
+
+  $effect(() => {
+    if (density !== "auto") return;
+    if (!ref) return;
+    if (typeof ResizeObserver === "undefined") return;
+
+    const update = () => {
+      availableWidth = ref.clientWidth;
+    };
+
+    update();
+
+    const ro = new ResizeObserver(() => update());
+    ro.observe(ref);
+
+    return () => ro.disconnect();
+  });
+
+  const resolvedDensity = $derived.by(() => {
+    if (density !== "auto") return normalizeDensity(density);
+
+    const w = Number(availableWidth);
+    if (!Number.isFinite(w) || w <= 0) return "regular";
+
+    if (w < compactBelow) return "compact";
+    if (w >= roomyAbove) return "roomy";
+    return "regular";
+  });
+
+  const resolvedTokens = $derived.by(() =>
+    resolveDensityTokens(resolvedDensity, tokens),
+  );
+
+  const densityStyle = $derived.by(() => {
+    const vars = densityTokensToCssVars(resolvedTokens);
+    return [`--fabkit-density: ${resolvedDensity}`, vars].filter(Boolean).join("; ");
+  });
+
+  const densityStore = writable({
+    density: "regular",
+    tokens: resolveDensityTokens("regular"),
+  });
+
+  setContext(DENSITY_CONTEXT_KEY, densityStore);
+
+  $effect(() => {
+    densityStore.set({ density: resolvedDensity, tokens: resolvedTokens });
+  });
+</script>
+
+<Skeleton
+  class="DensityProvider {className}"
+  bind:ref
+  style={densityStyle}
+  {...rest}
+>
+  {@render children?.()}
+</Skeleton>

--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -1,2 +1,3 @@
 export const CARD_RADIUS_CONTEXT_KEY = {};
 export const ADAPTIVE_LAYOUT_CONTEXT_KEY = {};
+export const DENSITY_CONTEXT_KEY = {};

--- a/src/lib/density.js
+++ b/src/lib/density.js
@@ -1,0 +1,60 @@
+export const DENSITIES = ["compact", "regular", "roomy"];
+
+export const DENSITY_TOKENS = {
+  compact: {
+    space2: 2,
+    space4: 4,
+    space8: 6,
+    space12: 10,
+    space16: 14,
+    space24: 20,
+    fontSize: 14,
+    controlHeight: 28,
+  },
+  regular: {
+    space2: 2,
+    space4: 4,
+    space8: 8,
+    space12: 12,
+    space16: 16,
+    space24: 24,
+    fontSize: 15,
+    controlHeight: 32,
+  },
+  roomy: {
+    space2: 3,
+    space4: 6,
+    space8: 10,
+    space12: 14,
+    space16: 20,
+    space24: 28,
+    fontSize: 16,
+    controlHeight: 40,
+  },
+};
+
+export function normalizeDensity(value) {
+  if (value === "compact" || value === "regular" || value === "roomy") return value;
+  return "regular";
+}
+
+export function resolveDensityTokens(density, overrides) {
+  const key = normalizeDensity(density);
+  const base = DENSITY_TOKENS[key];
+  if (!overrides) return base;
+  return { ...base, ...overrides };
+}
+
+export function densityTokensToCssVars(tokens) {
+  const entries = Object.entries(tokens);
+  return entries
+    .map(([k, v]) => {
+      if (typeof v === "number") {
+        if (k.toLowerCase().includes("fontsize")) return `--fabkit-density-${k}: ${v}px`;
+        if (k.toLowerCase().includes("height")) return `--fabkit-density-${k}: ${v}px`;
+        return `--fabkit-density-${k}: ${v}px`;
+      }
+      return `--fabkit-density-${k}: ${String(v)}`;
+    })
+    .join("; ");
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,6 +7,8 @@ export { defaultTheme } from "./defaultTheme.js";
 
 // System Utilities
 export { resolveProps } from "./system.js";
+export { DENSITIES, DENSITY_TOKENS, normalizeDensity, resolveDensityTokens } from "./density.js";
+export { getDensityStore } from "./DensityContext.js";
 
 // Components
 export { default as BaseField } from "./components/BaseField.svelte";
@@ -63,6 +65,7 @@ export { default as TextRich } from "./components/TextRich.svelte";
 export { default as TitleBar } from "./components/TitleBar.svelte";
 export { default as Window } from "./components/Window.svelte";
 export { default as Skeleton } from "./components/Skeleton.svelte";
+export { default as DensityProvider } from "./components/DensityProvider.svelte";
 export { default as Text } from "./components/Text.svelte";
 export { default as AdaptiveContent } from "./components/AdaptiveContent.svelte";
 export { default as ResponsiveSlot } from "./components/ResponsiveSlot.svelte";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,6 +58,7 @@ export const TextRich: Component<Record<string, any>>;
 export const TitleBar: Component<Record<string, any>>;
 export const Window: Component<Record<string, any>>;
 export const Skeleton: Component<Record<string, any>>;
+export const DensityProvider: Component<Record<string, any>>;
 export const Text: Component<Record<string, any>>;
 export const AdaptiveContent: Component<Record<string, any>>;
 export const ResponsiveSlot: Component<Record<string, any>>;
@@ -95,6 +96,13 @@ export function initTheme(...args: any[]): any;
 export function getTheme(...args: any[]): any;
 export function generateColorVariants(...args: any[]): any;
 export const defaultTheme: any;
+
+// Density
+export const DENSITIES: any;
+export const DENSITY_TOKENS: any;
+export function normalizeDensity(...args: any[]): any;
+export function resolveDensityTokens(...args: any[]): any;
+export function getDensityStore(...args: any[]): any;
 
 // Utils
 export const Engine: any;


### PR DESCRIPTION
Closes #76

Adds DensityProvider + density tokens (compact/regular/roomy), container-driven and SSR-safe. Updates exports, types, and docs.