### PR TITLE
fix: remove broken Flap export

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,6 @@
 - [AdaptiveLayout](./components/adaptive-layout.md) — container-driven breakpoints
 - [Breakpoint](./components/breakpoint.md) — breakpoint rule for AdaptiveLayout
 - [Leaflet](./components/leaflet.md) — adaptive two-pane stack
-- [Flap](./components/flap.md) — adaptive sidebar drawer
 - [Paned](./components/paned.md) — resizable two-panel split
 - [ToolbarView](./components/toolbar-view.md) — top/bottom bars + content
 - [HBox](./components/hbox.md) — horizontal flexbox row

--- a/docs/responsive-apps.md
+++ b/docs/responsive-apps.md
@@ -170,7 +170,7 @@ Bad:
 
 Better:
 
-- use `AdaptiveLayout` to move the sidebar into a drawer (`Flap`) when space is limited
+- use `AdaptiveLayout` to move the sidebar into an overflow pattern when space is limited
 
 
 ### Treating compact as a separate app

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -40,7 +40,6 @@ export { default as SideLayout } from "./components/SideLayout.svelte";
 export { default as AdaptiveLayout } from "./components/AdaptiveLayout.svelte";
 export { default as Breakpoint } from "./components/Breakpoint.svelte";
 export { default as Leaflet } from "./components/Leaflet.svelte";
-export { default as Flap } from "./components/Flap.svelte";
 export { default as Slider } from "./components/Slider.svelte";
 export { default as TextField } from "./components/TextField.svelte";
 export { default as VBox } from "./components/VBox.svelte";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,6 @@ export const SideLayout: Component<Record<string, any>>;
 export const AdaptiveLayout: Component<Record<string, any>>;
 export const Breakpoint: Component<Record<string, any>>;
 export const Leaflet: Component<Record<string, any>>;
-export const Flap: Component<Record<string, any>>;
 export const Slider: Component<Record<string, any>>;
 export const TextField: Component<Record<string, any>>;
 export const VBox: Component<Record<string, any>>;


### PR DESCRIPTION
Fixes CI failure in Actions run 22994930243: rollup couldn't resolve ./components/Flap.svelte (exported in src/lib/index.js but file doesn't exist).

Changes:
- Remove Flap export from src/lib/index.js
- Remove Flap from types/index.d.ts
- Remove Flap from docs index + adjust responsive guide wording
