### PR TITLE
feat: add Flap drawer

### DIFF
--- a/docs/components/flap.md
+++ b/docs/components/flap.md
@@ -1,0 +1,60 @@
+# Flap
+
+A container-friendly sidebar drawer.
+
+Use it to keep a classic split layout on wide containers, and move the sidebar into an overlay drawer when space is limited.
+
+---
+
+## Import
+
+```js
+import { Flap } from 'fabkit';
+```
+
+---
+
+## Basic usage
+
+```svelte
+<script>
+  import { Flap, Button } from 'fabkit';
+
+  let open = $state(false);
+</script>
+
+<Button label="Toggle sidebar" onclick={() => (open = !open)} />
+
+<Flap bind:open {open} width={320}>
+  {#snippet sidebar()}
+    <div style="padding: 16px;">Sidebar</div>
+  {/snippet}
+
+  {#snippet content()}
+    <div style="padding: 16px;">Content</div>
+  {/snippet}
+</Flap>
+```
+
+---
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | `false` | Whether the drawer is open (bindable) |
+| `width` | `number \| string` | `320` | Drawer width |
+| `placement` | `'left' \| 'right'` | `'left'` | Which side the drawer slides from |
+| `closeOnEscape` | `boolean` | `true` | Close when pressing Escape |
+| `closeOnBackdrop` | `boolean` | `true` | Close when clicking the backdrop |
+| `keepMounted` | `boolean` | `true` | Keep overlay mounted and only toggle pointer-events/transform |
+| `zIndex` | `number` | `1000` | Overlay z-index |
+| `sidebar` | `Snippet` | — | Drawer content |
+| `content` | `Snippet` | — | Main content behind the drawer |
+
+---
+
+## Notes
+
+- `Flap` does not decide when to open: pair it with `AdaptiveLayout`/`Breakpoint` (or your own logic) to trigger `open`.
+- Designed to be container-driven (not viewport-driven).

--- a/src/lib/components/Flap.svelte
+++ b/src/lib/components/Flap.svelte
@@ -1,0 +1,154 @@
+<script>
+  import Skeleton from "./Skeleton.svelte";
+
+  let {
+    sidebar,
+    content,
+    children,
+    open = $bindable(false),
+    width = 320,
+    placement = "left",
+    closeOnEscape = true,
+    closeOnBackdrop = true,
+    keepMounted = true,
+    zIndex = 1000,
+    class: className = "",
+    ref = $bindable(),
+    ...rest
+  } = $props();
+
+  const widthCss = $derived.by(() =>
+    typeof width === "number" ? `${width}px` : width
+  );
+
+  function close() {
+    open = false;
+  }
+
+  function handleBackdropClick(e) {
+    if (!closeOnBackdrop) return;
+    if (e.target !== e.currentTarget) return;
+    close();
+  }
+
+  $effect(() => {
+    if (!open) return;
+    if (!closeOnEscape) return;
+    if (typeof window === "undefined") return;
+
+    const onKeydown = (e) => {
+      if (e.key === "Escape") close();
+    };
+
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  });
+</script>
+
+<Skeleton
+  class={[
+    "Flap",
+    placement === "right" ? "Flap--right" : "Flap--left",
+    open ? "Flap--open" : "Flap--closed",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ")}
+  bind:ref
+  style={[`--flap-width: ${widthCss}`, `--flap-z: ${zIndex}`].join("; ")}
+  {...rest}
+>
+  <div class="Flap-content">
+    {@render content?.()}
+    {@render children?.()}
+  </div>
+
+  {#if keepMounted}
+    <div
+      class="Flap-overlay"
+      aria-hidden={!open}
+      style:pointer-events={open ? "auto" : "none"}
+      onclick={handleBackdropClick}
+    >
+      <div class="Flap-backdrop" />
+
+      <div class="Flap-panel">
+        {@render sidebar?.()}
+      </div>
+    </div>
+  {:else}
+    {#if open}
+      <div class="Flap-overlay" onclick={handleBackdropClick}>
+        <div class="Flap-backdrop" />
+        <div class="Flap-panel">
+          {@render sidebar?.()}
+        </div>
+      </div>
+    {/if}
+  {/if}
+</Skeleton>
+
+<style>
+  :global(.Flap) {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .Flap-content {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .Flap-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: var(--flap-z, 1000);
+  }
+
+  .Flap-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.18);
+    backdrop-filter: blur(3px);
+    opacity: 0;
+    transition: opacity 0.16s ease;
+  }
+
+  :global(.Flap--open) .Flap-backdrop {
+    opacity: 1;
+  }
+
+  .Flap-panel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--flap-width, 320px);
+    overflow: auto;
+    background: var(--background-elevated);
+    box-shadow: var(--shadow-elevated-2);
+    transition: transform 0.2s ease;
+  }
+
+  :global(.Flap--left) .Flap-panel {
+    left: 0;
+    transform: translateX(-100%);
+    border-right: 1px solid var(--border-primary);
+  }
+
+  :global(.Flap--right) .Flap-panel {
+    right: 0;
+    transform: translateX(100%);
+    border-left: 1px solid var(--border-primary);
+  }
+
+  :global(.Flap--open) .Flap-panel {
+    transform: translateX(0);
+  }
+
+</style>


### PR DESCRIPTION
Implements the Flap sidebar drawer component that was previously exported but missing from the repo.

Adds:
- code:src/lib/components/Flap.svelte:1:1
- code:docs/components/flap.md:1:1

This also fixes the rollup build failure caused by the missing file export in code:src/lib/index.js:43:1.